### PR TITLE
Add isCacheableValue argument to cache-manager in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const s3CacheStore = new S3Cache({
 
 const s3Cache = cacheManager.caching({
   store: s3CacheStore,
+  isCacheableValue: value => value !== undefined && value !== null,
 })
 
 s3Cache.set('foo', 'bar', {ttl: 360}, (err) => {


### PR DESCRIPTION
Not entirely sure this is the correct fix, but on a cache-miss cache-manager-S3 is returning a `null` as the value. cache-manager considers `value !== undefined` to be cacheable, and so happily returns the `null` as the value if you use `wrap`.

Using isCacheableValue fixes this. However it's probably a "more correct" fix if cache-manager-S3 returned `undefined` on a cache-miss. I don't have a PR for that though.